### PR TITLE
One Browser Session per Iteration

### DIFF
--- a/benchmark-iter.js
+++ b/benchmark-iter.js
@@ -6,8 +6,9 @@ const fs = require('fs');
 
 const url = `file://${__dirname}/build/index.html`;
 
-async function run(outfile, config = {}) {
-  const stream = fs.createWriteStream(outfile);
+async function run(outfile, config = {}, iter) {
+  const stream = fs.createWriteStream(outfile, { flags: iter > 0 ? "a" : undefined });
+  const iterUrl = `${url}?iter=${iter}`;
 
   const browser = await puppeteer.launch(config);
   const page = await browser.newPage();
@@ -15,7 +16,7 @@ async function run(outfile, config = {}) {
   await page.setCacheEnabled(false);
   await page.reload({ waitUntil: 'networkidle2' });
 
-  await page.goto(url);
+  await page.goto(iterUrl);
 
   let first = false;
   page.on('console', async msg => {
@@ -28,8 +29,11 @@ async function run(outfile, config = {}) {
       const records = JSON.parse(msg.text());
       if (!first) {
         const headers = Object.keys(records[0]).join(',');
-        stream.write(headers + '\n', 'utf-8');
-        first = true;
+        // Only write headers on first pass.
+        if (iter === 0) {
+          stream.write(headers + '\n', 'utf-8');
+          first = true;
+        }
       }
       for (const record of records) {
         const values = Object.values(record).join(',');
@@ -42,15 +46,25 @@ async function run(outfile, config = {}) {
 function main() {
   const args = process.argv.slice(2);
   if (args.length < 1) {
-    console.log("./benchmark.js <filename> [--no-headless] [--ignore-https-errors] [chrome_flags]")
-    process.exit(1);
+    exitOnBadArgs('No args found.');
   }
   const outfile = args[0];
-  const flags = new Set(args.slice(1));
+  const flags = new Set(args.slice(1, -2));
   const headless = !flags.delete('--no-headless');
   const ignoreHTTPSErrors = flags.has("--ignore-https-errors");
+  const [iterArg] = args.slice(-2);
+  if (iterArg !== '-iter') {
+    exitOnBadArgs(`-iter arg is not correct - found ${iterArg}`);
+  }
+  const [iter] = args.slice(-1);
   console.log("running with args: ", { headless, ignoreHTTPSErrors, args: [...flags] });
-  run(outfile, { headless, ignoreHTTPSErrors, args: [...flags] });
+  run(outfile, { headless, ignoreHTTPSErrors, args: [...flags] }, Number(iter));
+}
+
+function exitOnBadArgs(message) {
+  console.log(message)
+  console.log("./benchmark-iter.js <filename> [--no-headless] [--ignore-https-errors] [chrome_flags] [-iter i]")
+  process.exit(1);
 }
 
 main();

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "start": "webpack-dev-server --hot",
     "build": "webpack -p",
-    "bench:h1": "./benchmark.js chrome_http1.csv --disable-http2 --ignore-https-errors --no-headless",
-    "bench:h2": "./benchmark.js chrome_http2.csv --ignore-https-errors --no-headless",
+    "bench:h1": "./run_benchmark.sh chrome_http1.csv --disable-http2 --ignore-https-errors --no-headless",
+    "bench:h2": "./run_benchmark.sh chrome_http2.csv --ignore-https-errors --no-headless",
     "bench": "npm run build && npm run bench:h1 && npm run bench:h2"
   },
   "author": "Trevor James Manz",

--- a/run_benchmark.sh
+++ b/run_benchmark.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -o errexit
+die() { set +v; echo "$*" 1>&2 ; exit 1; }
+
+echo $@
+
+# Run 10 iterations.
+for i in $(seq 0 10); do 
+   node ./benchmark-iter.js $@ "-iter" $i
+done

--- a/run_benchmark.sh
+++ b/run_benchmark.sh
@@ -2,8 +2,6 @@
 set -o errexit
 die() { set +v; echo "$*" 1>&2 ; exit 1; }
 
-echo $@
-
 # Run 10 iterations.
 for i in $(seq 0 10); do 
    node ./benchmark-iter.js $@ "-iter" $i

--- a/run_benchmark.sh
+++ b/run_benchmark.sh
@@ -4,5 +4,5 @@ die() { set +v; echo "$*" 1>&2 ; exit 1; }
 
 # Run 10 iterations.
 for i in $(seq 0 10); do 
-   node ./benchmark-iter.js $@ "-iter" $i
+   node ./benchmark-iter.js $@ -iter $i
 done

--- a/src/index.js
+++ b/src/index.js
@@ -65,9 +65,8 @@ async function timeRegions({ file, sources, regions }, iter) {
 async function main() {
   console.time('Run benchmark.')
   for (const img of images) {
-    for (let i = 0; i < ITERS; i++) {
-      await timeRegions(img, i);
-    }
+    const iter = window.location.href.split('?')[1].split('=')[1];
+    await timeRegions(img, iter);
   }
   console.timeEnd('Run benchmark.')
 }


### PR DESCRIPTION
I was having issues where my browser was crashing about 30000 requests in (so about 15% of the way through).   This makes it so that each browser session lasts only one iteration (so %10). 

 I regrettably wrote a small shell script to handle this.  I could not figure out how to handle the highly asynchronous nature of the long running processes we use.  It seems like the entire node script (formerly `benchmark.js`) would execute (finishing completely) and puppeteer would then keep the process alive while the connection was alive, with `page.on` still listening.  To get around that I wrote a shell script but I would certainly be open to cleaner options - everything I could think of involved some measure of recursion which is what prompted me to use bash, since those commands finish when the process exits as opposed to the script finishing execuciton.

I'm going to run this tonight and see what happens.